### PR TITLE
167796250 Adding Yotpo::ProductGroup api calls

### DIFF
--- a/lib/yotpo/api/product_group.rb
+++ b/lib/yotpo/api/product_group.rb
@@ -1,0 +1,46 @@
+module Yotpo
+  module ProductGroup
+    def create_product_group(params, headers = {})
+      request = {
+        group_name: params[:group_name],
+        utoken: params[:utoken]
+      }
+      app_key = params[:app_key]
+      post("/v1/apps/#{app_key}/products_groups", request, headers)
+    end
+
+    def get_account_product_groups(params, headers = {})
+      request = {
+        utoken: params[:utoken]
+      }
+      app_key = params[:app_key]
+      get("/v1/apps/#{app_key}/products_groups", request, headers)
+    end
+
+    def get_product_group_by_name(params, headers = {})
+      request = {
+        utoken: params[:utoken]
+      }
+      app_key = params[:app_key]
+      get("/v1/apps/#{app_key}/products_groups/#{params[:group_name]}", request, headers)
+    end
+
+    def add_remove_products(params, headers = {})
+      request = {
+        utoken: params[:utoken],
+        product_ids_to_add: params[:product_ids_to_add],
+        product_ids_to_remove: params[:product_ids_to_remove]
+      }
+      app_key = params[:app_key]
+      put("/v1/apps/#{app_key}/products_groups/#{params[:group_name]}", request, headers)
+    end
+
+    def delete_product_group_by_name(params, headers = {})
+      request = {
+        utoken: params[:utoken]
+      }
+      app_key = params[:app_key]
+      delete("/v1/apps/#{app_key}/products_groups/#{params[:group_name]}", request, headers)
+    end
+  end
+end

--- a/lib/yotpo/client.rb
+++ b/lib/yotpo/client.rb
@@ -17,6 +17,7 @@ require 'yotpo/api/image'
 require 'yotpo/api/owner_feature'
 require 'yotpo/api/owner_feature_setting'
 require 'yotpo/api/product'
+require 'yotpo/api/product_group'
 require 'yotpo/api/purchase'
 require 'yotpo/api/reminder'
 require 'yotpo/api/review'
@@ -34,6 +35,7 @@ module Yotpo
     include Yotpo::OwnerFeature
     include Yotpo::OwnerFeatureSetting
     include Yotpo::Product
+    include Yotpo::ProductGroup
     include Yotpo::Reminder
     include Yotpo::Review
     include Yotpo::User


### PR DESCRIPTION
## Example calls
```
Yotpo.create_product_group(
  app_key: Yotpo.app_key,
  utoken: fetch_utoken,
  group_name: "5624-502"
)


Yotpo.get_account_product_groups(
  app_key: Yotpo.app_key,
  utoken: fetch_utoken
)


Yotpo.add_remove_products(
  app_key: Yotpo.app_key,
  utoken: fetch_utoken,
  group_name: "5624-502",
  product_ids_to_add: ['5624-502-L']
)


Yotpo.get_product_group_by_name(
  app_key: Yotpo.app_key,
  utoken: fetch_utoken,
  group_name: "5624-502"
)


Yotpo.delete_product_group_by_name(
  app_key: Yotpo.app_key,
  utoken: fetch_utoken,
  group_name: "5624-502"
)
```